### PR TITLE
Resolution Attempt for Issue #18

### DIFF
--- a/js/AppControls.js
+++ b/js/AppControls.js
@@ -32,7 +32,8 @@ var AppControls = React.createClass({
 	},
 	render: function () {
 		var {callback, appState: {cohort, cohorts, samplesFrom, datasets, mode}} = this.props,
-			hasCohort = !!cohort;
+			hasCohort = !!cohort,
+			disableMenus = (mode === modeEvent.heatmap);
 
 		const tooltip = <Tooltip id='reload-cohorts'>Reload cohorts from all hubs.</Tooltip>
 		return (
@@ -42,7 +43,7 @@ var AppControls = React.createClass({
 						<span className="glyphicon glyphicon-refresh" aria-hidden="true"/>
 					</Button>
 				</OverlayTrigger>
-				<CohortSelect callback={callback} cohort={cohort} cohorts={cohorts} />
+				<CohortSelect callback={callback} cohort={cohort} cohorts={cohorts} disable={disableMenus}/>
 				{' '}
 				{hasCohort ?
 					<div className='form-group' style={this.props.style}>
@@ -57,6 +58,7 @@ var AppControls = React.createClass({
 							className='samplesFromAnchor'
 							datasets={datasets}
 							cohort={cohort}
+							disable={disableMenus}
 							value={samplesFrom} />
 					</div> :
 				null}

--- a/js/CohortSelect.js
+++ b/js/CohortSelect.js
@@ -8,7 +8,7 @@ var {deepPureRenderMixin} = require('./react-utils');
 var CohortSelect = React.createClass({
 	mixins: [deepPureRenderMixin],
 	render: function () {
-		var {cohort, cohorts, callback} = this.props,
+		var {cohort, cohorts, callback, ...other} = this.props,
 			sortedCohorts = _.sortBy(cohorts, (cohort) => cohort.toLowerCase()),
 			options = _.map(sortedCohorts, c => ({value: c, label: c}));
 
@@ -21,6 +21,7 @@ var CohortSelect = React.createClass({
 					callback={callback}
 					value={cohort}
 					options={options}
+					{...other}
 				/>
 			</div>
 		);

--- a/js/Select.js
+++ b/js/Select.js
@@ -28,6 +28,7 @@ var Select = React.createClass({
 	},
 	getDefaultProps: function () {
 		return {
+			disable: false,
 			event: 'change'
 		};
 	},
@@ -57,7 +58,7 @@ var Select = React.createClass({
 		}
 	},
 	render: function () {
-		var {value} = this.props,
+		var {disable, value} = this.props,
 			title = notUndefined(value) &&
 				_.find(this.props.options, opt => opt.value === value),
 			opts = filterOpts(this.state.filter, this.props.options);
@@ -68,6 +69,7 @@ var Select = React.createClass({
 		return (
 			<DropdownButton ref='dropdown'
 				className='Select'
+				disabled={disable}
 				onMouseUp={this.setFocus}
 				title={title && title.label || 'Select...'}>
 


### PR DESCRIPTION
https://github.com/acthp/ucsc-xena-client/issues/18

DatasetSelect.js
1) With new line 29, I originally wanted to use _.find( ), but realized that directly referencing the key was faster.  Moreover, this approach of obtaining the corresponding label for the chosen value, is an attempt at providing consistency in how the chosen value is offered to Select.js via CohortSelect and DatasetSelect.
2) With new line 30 `other = _.assoc(other, "value", dataset.label);`, I am assuming that mutating this.props.other would be problematic, therefore the usage of .assoc( ).  Not sure if React already account for this with their props solution.