### PR TITLE
Fixing Firefox Download Issue (issue #37)

### DIFF
--- a/js/Column.js
+++ b/js/Column.js
@@ -17,9 +17,11 @@ function download([fields, rows]) {
 	// use blob for bug in chrome: https://code.google.com/p/chromium/issues/detail?id=373182
 	var url = URL.createObjectURL(new Blob([txt], { type: 'text/tsv' }));
 	var a = document.createElement('a');
-	a.href = url;
-	a.setAttribute('download', 'xenaDownload.tsv');
+	var filename = 'xenaDownload.tsv';
+	_.extend(a, { id: filename, download: filename, href: url });
+	document.body.appendChild(a);
 	a.click();
+	document.body.removeChild(a);
 }
 
 // For geneProbesMatrix we will average across probes to compute KM. For


### PR DESCRIPTION
In order for the click event to work in Firefox as intended on an element (e.g. prompt for file download), it has to reside on document.body.  Also tested XENA on Chrome after altering codebase -- works as expected.

Represented in issue https://github.com/acthp/ucsc-xena-client/issues/21